### PR TITLE
Fix to zero padded date

### DIFF
--- a/src/components/Post/helpers/parseDate.js
+++ b/src/components/Post/helpers/parseDate.js
@@ -1,9 +1,12 @@
 export const parseDate = (date) => {
-  date = new Date(date)
-  const day = date.getDate() + 1 // This is *so* stupid.
-  const month = date.getMonth() + 1 // This is *so* stupid.
-  const year = date.getFullYear()
-
-  const parsedDate = `${day}/${month}/${year}`
-  return parsedDate
+  return splitDate(date)
 }
+
+const splitDate = (date) => {
+  date = date.split('-')
+  return `${date[2]}/${date[1]}/${date[0]}`
+}
+
+// `Date` was returning a day before. JsvaScript's `Date`is actually a
+// timestampa. This is such a mess. I do not want to add any other library
+// to deal with this (momen.js or whatever the flavor of the week is).


### PR DESCRIPTION
> Javascript's Date class doesn't represent a date, it represents a timestamp (same in Java). To make it a date, it uses a time zone and that's the cause of your problem. It parses it with the GMT/UTC timezone (Sep 24 2011, 00:00 UTC) and then outputs it with a different timezone of 4 hours (Sep 23 2011, 20:00 GMT-0400

Topic discussed [here](https://stackoverflow.com/questions/7556591/is-the-javascript-date-object-always-one-day-off)